### PR TITLE
Step 4: Component port — Gatsby/Emotion → Tailwind v4

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { Ovo, Mulish } from "next/font/google";
+import Header from "@/components/Header/Header";
+import Layout from "@/components/Layout/Layout";
+import Footer from "@/components/Footer/Footer";
 import "./globals.css";
 
 const ovo = Ovo({
@@ -31,7 +34,9 @@ export default function RootLayout({
       className={`${ovo.variable} ${mulish.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-background text-text font-sans leading-relaxed">
-        {children}
+        <Header />
+        <Layout>{children}</Layout>
+        <Footer />
       </body>
     </html>
   );

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+interface ButtonProps {
+  href: string;
+  children: React.ReactNode;
+}
+
+export default function Button({ href, children }: ButtonProps) {
+  return (
+    <Link
+      href={href}
+      className="bg-highlight-2 !text-background rounded-[0.4rem] block font-bold mt-[5.5rem] mx-auto opacity-80 py-4 px-6 w-fit transition-opacity duration-500 hover:opacity-100"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,0 +1,12 @@
+import SocialLinks from '@/components/SocialLinks/SocialLinks';
+
+export default function Footer() {
+  return (
+    <footer className="bg-shadow mt-auto p-10 sm:flex sm:items-center sm:justify-between">
+      <p className="m-0 mr-8">
+        Copyright &copy; {new Date().getFullYear()} Daniel W Robert. All rights reserved.
+      </p>
+      <SocialLinks />
+    </footer>
+  );
+}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,0 +1,9 @@
+import Nav from '@/components/Nav/Nav';
+
+export default function Header() {
+  return (
+    <header className="bg-shadow shadow-[0_0.5rem_1rem_0_rgba(0,0,0,0.15)] p-10">
+      <Nav />
+    </header>
+  );
+}

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="max-w-[79rem] mx-auto px-10 py-28 w-full">
+      {children}
+    </div>
+  );
+}

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function Nav() {
+  const pathname = usePathname();
+
+  return (
+    <nav>
+      <ul className="flex flex-row items-center list-none m-0 p-0">
+        <li className="font-serif text-[2.5rem] ml-[15px] mr-auto">
+          <Link href="/" className={pathname === '/' ? 'active' : ''}>
+            DWR
+          </Link>
+        </li>
+        <li className="mx-[15px]">
+          <Link
+            href="/notebook"
+            className={pathname?.startsWith('/notebook') ? 'active' : ''}
+          >
+            Notebook
+          </Link>
+        </li>
+        <li className="mx-[15px]">
+          <Link
+            href="/about"
+            className={pathname === '/about' ? 'active' : ''}
+          >
+            About
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/components/SocialLinks/SocialLinks.tsx
+++ b/components/SocialLinks/SocialLinks.tsx
@@ -1,0 +1,32 @@
+import { Twitter, GitHub, Rss } from 'react-feather';
+
+export default function SocialLinks() {
+  return (
+    <div className="flex mt-6 sm:mt-0">
+      <a
+        href="https://twitter.com/danielwrobert"
+        rel="external"
+        className="text-shadow-light hover:text-highlight-3 mr-8 inline-flex"
+        aria-label="Twitter"
+      >
+        <Twitter className="w-[3.2rem] h-[3.2rem]" />
+      </a>
+      <a
+        href="https://github.com/danielwrobert"
+        rel="external"
+        className="text-shadow-light hover:text-highlight-3 mr-8 inline-flex"
+        aria-label="GitHub"
+      >
+        <GitHub className="w-[3.2rem] h-[3.2rem]" />
+      </a>
+      <a
+        href="/rss.xml"
+        rel="external"
+        className="text-shadow-light hover:text-highlight-3 inline-flex"
+        aria-label="RSS Feed"
+      >
+        <Rss className="w-[3.2rem] h-[3.2rem]" />
+      </a>
+    </div>
+  );
+}

--- a/components/Stitch/Stitch.tsx
+++ b/components/Stitch/Stitch.tsx
@@ -1,0 +1,30 @@
+interface StitchProps {
+  color?: string;
+  strokeWidth?: string;
+  width?: string;
+  margin?: string;
+}
+
+export default function Stitch({
+  color = 'var(--color-shadow-light)',
+  strokeWidth = '4',
+  width = '4.5rem',
+  margin = '0 auto 4.5rem',
+}: StitchProps) {
+  return (
+    <svg
+      id="stitch"
+      data-name="stitch"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 87.5 23.1"
+      style={{ display: 'block', margin, stroke: color, strokeWidth, width }}
+    >
+      <line x1="0.1" y1="13.4" x2="87.4" y2="10.2" fill="none" />
+      <line x1="42.4" y1="0.8" x2="43.6" y2="21.8" fill="none" />
+      <line x1="59.2" y1="0.4" x2="60.4" y2="21.4" fill="none" />
+      <line x1="75.8" y1="0.1" x2="77" y2="21.1" fill="none" />
+      <line x1="26.3" y1="1.1" x2="27.4" y2="22.1" fill="none" />
+      <line x1="9.7" y1="2" x2="10.9" y2="23" fill="none" />
+    </svg>
+  );
+}

--- a/components/TOC/TOC.tsx
+++ b/components/TOC/TOC.tsx
@@ -1,0 +1,8 @@
+export default function TOC({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-shadow rounded-[0.5rem] p-6 my-[1.8rem]">
+      <h2 className="!text-highlight-4">Series Table of Contents:</h2>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Migration step 4 of 7: ports all eight UI components from Gatsby/Emotion to Tailwind v4, and wires the chrome into `app/layout.tsx`.

### New components

| Component | Source | Notes |
|---|---|---|
| `Layout` | `src/components/layout.js` | `max-w-[79rem] mx-auto px-10 py-28 w-full` content column |
| `Header` | `src/components/header.js` | `bg-shadow` band + drop shadow, wraps `Nav` |
| `Nav` | `src/components/nav.js` | `"use client"` — uses `usePathname` to apply `active` class; DWR logo is `font-serif text-[2.5rem] mr-auto` |
| `Footer` | `src/components/footer.js` | `bg-shadow` band, copyright + `SocialLinks`, flex at `sm:` |
| `SocialLinks` | `src/components/social-links.js` | Twitter / GitHub / RSS via `react-feather` (correct export is `GitHub` not `Github`); icons sized `w-[3.2rem]` to match Gatsby's `3.2rem` width |
| `Button` | `src/components/button.js` | `bg-highlight-2 !text-background` (important needed to override global link color); `opacity-80 hover:opacity-100` |
| `Stitch` | `src/components/stitch.js` | SVG separator; dynamic `color`/`strokeWidth`/`width`/`margin` props via inline styles |
| `TOC` | `src/components/toc.js` | `bg-shadow` box, `!text-highlight-4` heading to override global h2 cyan |

### `app/layout.tsx`
Added `Header`, `Layout`, and `Footer` imports. The body now reads:
```tsx
<Header />
<Layout>{children}</Layout>
<Footer />
```

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run dev` — visit `http://localhost:3000`
- [ ] Header renders with dark `#282a36` background and contains "DWR", "Notebook", "About" links
- [ ] Clicking a nav link applies the `active` class (styled as pink in `globals.css`)
- [ ] Footer renders at the bottom with copyright year and the three social icons
- [ ] Content area is centered and max-width constrained
- [ ] Social icon hover turns green (`--color-highlight-3`)

https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11)_