### PR TITLE
Step 5: App Router pages — home, notebook, about, [slug], 404

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { format, parseISO } from "date-fns";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { getBlogPostList, loadBlogPost } from "@/lib/helpers/file-helpers";
+import COMPONENT_MAP from "@/lib/helpers/mdx-components";
+import Stitch from "@/components/Stitch/Stitch";
+import Button from "@/components/Button/Button";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateStaticParams() {
+  const posts = await getBlogPostList();
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const { frontmatter } = await loadBlogPost(slug);
+  return {
+    title: `${frontmatter.title} — Daniel W. Robert`,
+    description: frontmatter.excerpt,
+  };
+}
+
+export default async function PostPage({ params }: Props) {
+  const { slug } = await params;
+  const { frontmatter, content } = await loadBlogPost(slug);
+
+  const { title, date, updated } = frontmatter;
+  const dateLabel = updated
+    ? `Updated on ${format(parseISO(updated), "MM/dd/yyyy")}`
+    : `Published on ${format(parseISO(date), "MM/dd/yyyy")}`;
+  const dateClass = updated ? "entry-meta-updated" : "entry-meta";
+
+  return (
+    <>
+      <h1 className="entry-title text-highlight-3">{title}</h1>
+      <p className={dateClass}>{dateLabel}</p>
+      <Stitch />
+      <MDXRemote source={content} components={COMPONENT_MAP} />
+      <hr className="mt-[4.5rem] mb-[2.5rem] opacity-50" />
+      <Button href="/notebook">&larr; Back to all notes</Button>
+    </>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Stitch from "@/components/Stitch/Stitch";
+
+export const metadata: Metadata = {
+  title: "About — Daniel W. Robert",
+  description: "About my Digital Notebook.",
+};
+
+export default function About() {
+  return (
+    <>
+      <h1 className="entry-title text-highlight-3">About My Notebook</h1>
+      <Stitch />
+      <h2>Welcome!</h2>
+      <p>
+        This site is meant to serve as a Digital Notebook, of sorts. The
+        content you will find here is made up of my notes and learnings—
+        whether they be from a course I&apos;ve taken, a book or article
+        I&apos;ve read, or something interesting I&apos;ve discovered in
+        experimenting.
+      </p>
+      <p>
+        Writing things out, in my own words, allows me to solidify my
+        understanding of what I am learning. It also serves as a nice reference
+        to look back on when trying to recall something (as opposed to trying
+        to search around for &ldquo;that one article I read on a particular
+        topic once&rdquo;).
+      </p>
+      <p>
+        Hopefully, some of my notes here will be helpful for you in your
+        learning journey as well!
+      </p>
+      <p>
+        Instead of getting hung up on producing perfectly curated articles, I
+        may often post some of my notes/thoughts and circle back to them later,
+        if necessary.
+      </p>
+      <p>
+        While maybe not <em>exactly</em> the same thing, this isn&apos;t too
+        far off from the whole{" "}
+        <a href="https://joelhooks.com/digital-garden">&ldquo;Digital Garden&rdquo;</a>{" "}
+        idea:
+      </p>
+      <blockquote>
+        &ldquo;It is a blog, sure, but it is also a wiki. It&apos;s a spot
+        where I can post ideas, snippets, resources, thoughts, collections, and
+        other bits and pieces that I find interesting and useful. Instead of
+        always being a &lsquo;performance&rsquo; level of blogging, it can be a
+        looser more human endeavor that drops the idea of robots sorting the
+        content (in this case simply by date created) and embraces the idea of
+        curation, by me, for you.&rdquo;
+      </blockquote>
+
+      <h2>Under The Hood</h2>
+      <p>
+        This site is built with{" "}
+        <a href="https://nextjs.org/">Next.js</a> and hosted on{" "}
+        <a href="https://www.netlify.com/">Netlify</a>.
+      </p>
+      <p>
+        The posts are written in{" "}
+        <a href="https://mdxjs.com/">Markdown (MDX)</a>.
+      </p>
+
+      <h3>Colors</h3>
+      <p>
+        I&apos;ve styled this site to use the colors from the{" "}
+        <a href="https://draculatheme.com/">Dracula</a> color scheme. I&apos;m
+        using that scheme in just about all of my apps (VS Code, Vim, iTerm 2,
+        Bear, MacDown, etc.) and I love it!
+      </p>
+
+      <h3>Fonts</h3>
+      <p>
+        This site uses{" "}
+        <a href="https://fonts.google.com/specimen/Mulish">Mulish</a> for the
+        body font and{" "}
+        <a href="https://fonts.google.com/specimen/Ovo">Ovo</a> for the
+        headings, loaded via <code>next/font/google</code>.
+      </p>
+    </>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <>
+      <h1 className="entry-title text-highlight-3">404</h1>
+      <p className="text-center">
+        Page not found.{" "}
+        <Link href="/">Return home &rarr;</Link>
+      </p>
+    </>
+  );
+}

--- a/app/notebook/page.tsx
+++ b/app/notebook/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { format, parseISO } from "date-fns";
+import { getBlogPostList } from "@/lib/helpers/file-helpers";
+import Stitch from "@/components/Stitch/Stitch";
+
+export const metadata: Metadata = {
+  title: "Notebook — Daniel W. Robert",
+  description: "My open collection of notes, resources, and explorations.",
+};
+
+export default async function Notebook() {
+  const posts = await getBlogPostList();
+
+  return (
+    <>
+      <h1 className="entry-title text-highlight-3">Notebook</h1>
+      <Stitch />
+      <p>
+        My open collection of notes, resources, and explorations I&apos;m
+        currently working on. This is a place for me to post ideas, snippets,
+        resources, course notes, etc.
+      </p>
+      {posts.map((post) => (
+        <article className="note" key={post.slug}>
+          <h2>
+            <Link href={`/${post.slug}`}>{post.title}</Link>
+          </h2>
+          <h5 className="italic mb-4">
+            {format(parseISO(post.date), "MM/dd/yyyy")}
+          </h5>
+          <p>{post.excerpt}</p>
+          <Link href={`/${post.slug}`}>Read note &rarr;</Link>
+        </article>
+      ))}
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,65 +1,43 @@
-import Image from "next/image";
+import Link from "next/link";
+import { format, parseISO } from "date-fns";
+import { getBlogPostList } from "@/lib/helpers/file-helpers";
+import Stitch from "@/components/Stitch/Stitch";
+import Button from "@/components/Button/Button";
 
-export default function Home() {
+export default async function Home() {
+  const posts = await getBlogPostList();
+  const latestPosts = posts.slice(0, 3);
+
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
+    <>
+      <h1 className="entry-title text-highlight-3">Daniel W. Robert</h1>
+      <h3 className="text-highlight-1 italic mb-6 text-center">
+        Front-End Engineer. Always a student.
+      </h3>
+      <Stitch />
+      <p>Hello and welcome to my Digital Notebook!</p>
+      <p>
+        I&apos;m a Front-End Engineer at{" "}
+        <a href="https://automattic.com">Automattic</a> – the company behind
+        WordPress.com, Jetpack, WooCommerce, Tumblr, Gravatar, and a bunch of
+        other cool products that you may have seen around the web.
+      </p>
+      <h2 className="mb-[1.8rem]">Latest Notes:</h2>
+      {latestPosts.map((post) => (
+        <article className="note" key={post.slug}>
+          <h3>
+            <Link href={`/${post.slug}`} className="text-highlight-1">
+              {post.title}
+            </Link>
+          </h3>
+          <h5 className="italic mb-4">
+            {format(parseISO(post.date), "MM/dd/yyyy")}
+          </h5>
+          <p>{post.excerpt}</p>
+          <Link href={`/${post.slug}`}>Read note &rarr;</Link>
+        </article>
+      ))}
+      <Button href="/notebook">View all notes</Button>
+    </>
   );
 }

--- a/content/2017/ubuntu-mate-on-raspberry-pi.mdx
+++ b/content/2017/ubuntu-mate-on-raspberry-pi.mdx
@@ -23,7 +23,7 @@ Before moving forward, you’ll need the following items:
 
 ### Preparing the microSD card
 
-Download the latest Ubuntu Mate image from <https://ubuntu-mate.org/download/>.
+Download the latest Ubuntu Mate image from [ubuntu-mate.org/download/](https://ubuntu-mate.org/download/).
 
 You will want to click and expand the LTS option and you will see the Raspberry Pi specific download option from there.
 

--- a/lib/helpers/file-helpers.js
+++ b/lib/helpers/file-helpers.js
@@ -3,6 +3,17 @@ import path from 'path';
 import matter from 'gray-matter';
 import React from 'react';
 
+/**
+ * @typedef {Object} BlogPost
+ * @property {string} slug
+ * @property {string} title
+ * @property {string} date
+ * @property {string} excerpt
+ * @property {string[]} [tags]
+ * @property {string} [updated]
+ */
+
+/** @returns {Promise<BlogPost[]>} */
 export async function getBlogPostList() {
   const yearDirs = await readDirectory('/content');
 


### PR DESCRIPTION
## Summary

Migration step 5 of 7: all pages are implemented. The site is now fully navigable.

### Pages created

| Route | File | Notes |
|---|---|---|
| `/` | `app/page.tsx` | Green `entry-title` h1, purple italic tagline, `<Stitch />`, intro copy, latest 3 posts as `.note` cards, `<Button>` to `/notebook` |
| `/notebook` | `app/notebook/page.tsx` | All 27 posts as `.note` cards, sorted newest-first |
| `/about` | `app/about/page.tsx` | Content ported verbatim from Gatsby; "Under The Hood" updated to reference Next.js |
| `/[slug]` | `app/[slug]/page.tsx` | `generateStaticParams` lists all 27 slugs; `generateMetadata` reads frontmatter; date line uses `.entry-meta` / `.entry-meta-updated` global classes; `MDXRemote` renders content with `COMPONENT_MAP` |
| `*` | `app/not-found.tsx` | Minimal 404 with home link |

### Other changes

- **`app/layout.tsx`** — re-adds `Header`, `Layout`, `Footer` chrome (removed from main after Step 4 merge; required for pages to render correctly)
- **`lib/helpers/file-helpers.js`** — added `@typedef BlogPost` JSDoc so TypeScript knows `getBlogPostList()` returns `{ slug, title, date, excerpt, tags?, updated? }[]`
- **`content/2017/ubuntu-mate-on-raspberry-pi.mdx`** — fixed one bare `<https://...>` autolink that MDX was interpreting as invalid JSX; converted to `[text](url)` syntax

### Build output
```
Route (app)
┌ ○ /
├ ○ /_not-found
├ ● /[slug]         [+27 paths]
├ ○ /about
└ ○ /notebook
```
33 static pages total — all 27 post routes generated at build time via `generateStaticParams`.

## Test plan

- [ ] `npm run build` succeeds (33 pages, no errors)
- [ ] `npm start` — visit `/`: Dracula theme, Ovo serif heading, Mulish body, latest 3 posts visible
- [ ] `/notebook` — all 27 posts listed
- [ ] `/about` — content renders, no layout shift
- [ ] A post with code blocks (e.g. `/viewing-apache-logs-with-tail-and-grep`) — code rendered with Dracula syntax highlighting via `bright`
- [ ] A post with images (e.g. `/quicktip-debugging-safari-ios`) — images load from `/images/quicktip-debugging-safari-ios/`
- [ ] A post with an `updated` field (e.g. `/javascript-core-components-of-execution`) — date line reads "Updated on …" in orange rather than purple
- [ ] Nav active state highlights the current page link
- [ ] "← Back to all notes" button on post pages navigates to `/notebook`

https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11)_