### PR TITLE
Step 6: SEO metadata, RSS feed, sitemap

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -19,8 +19,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const { frontmatter } = await loadBlogPost(slug);
   return {
-    title: `${frontmatter.title} — Daniel W. Robert`,
+    title: frontmatter.title,
     description: frontmatter.excerpt,
+    openGraph: {
+      title: frontmatter.title,
+      description: frontmatter.excerpt,
+      type: "article",
+      publishedTime: frontmatter.date,
+      modifiedTime: frontmatter.updated,
+    },
+    twitter: {
+      card: "summary",
+      title: frontmatter.title,
+      description: frontmatter.excerpt,
+    },
   };
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,9 +18,31 @@ const mulish = Mulish({
   display: "swap",
 });
 
+const SITE_URL = "https://dwr.io";
+const SITE_TITLE = "Daniel W. Robert";
+const SITE_DESCRIPTION =
+  "Front-End Engineer. Always a student. This is my Digital Notebook";
+
 export const metadata: Metadata = {
-  title: "Daniel W. Robert",
-  description: "Front-End Engineer. Always a student. This is my Digital Notebook",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_TITLE,
+    template: `%s — ${SITE_TITLE}`,
+  },
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: "dwr.io",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    creator: "@danielwrobert",
+  },
 };
 
 export default function RootLayout({

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,0 +1,40 @@
+import { getBlogPostList } from "@/lib/helpers/file-helpers";
+
+const SITE_URL = "https://dwr.io";
+const FEED_TITLE = "DWR.IO";
+const FEED_DESCRIPTION = "My Digital Notebook";
+
+export async function GET() {
+  const posts = await getBlogPostList();
+
+  const items = posts
+    .map(
+      (post) => `
+    <item>
+      <title><![CDATA[${post.title}]]></title>
+      <description><![CDATA[${post.excerpt}]]></description>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <link>${SITE_URL}/${post.slug}</link>
+      <guid>${SITE_URL}/${post.slug}</guid>
+    </item>`
+    )
+    .join("");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${FEED_TITLE}</title>
+    <description>${FEED_DESCRIPTION}</description>
+    <link>${SITE_URL}</link>
+    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml"/>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from "next";
+import { getBlogPostList } from "@/lib/helpers/file-helpers";
+
+const SITE_URL = "https://dwr.io";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getBlogPostList();
+
+  const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/${post.slug}`,
+    lastModified: new Date(post.updated ?? post.date),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  return [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/notebook`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
+    ...postEntries,
+  ];
+}


### PR DESCRIPTION
## Summary

Migration step 6 of 7: replaces Gatsby's React Helmet SEO component and `gatsby-plugin-feed` / `gatsby-plugin-sitemap` with Next.js native equivalents.

### Metadata (`app/layout.tsx` + `app/[slug]/page.tsx`)

The Gatsby `seo.js` component set `og:title`, `og:description`, `twitter:title`, `twitter:description`, and `meta description` on every page. The replacement:

- **Root `app/layout.tsx`** — adds `metadataBase: new URL('https://dwr.io')`, a `title.template` of `%s — Daniel W. Robert` (so page titles auto-suffix), and default `openGraph` + `twitter` objects for the site level
- **`app/[slug]/page.tsx` `generateMetadata`** — now returns `openGraph` (type `article`, `publishedTime`, `modifiedTime`) and `twitter` fields populated from frontmatter, in addition to the existing `title`/`description`
- Static pages (`/`, `/notebook`, `/about`) inherit root defaults; their existing `metadata` exports provide page-specific titles that flow through the template

### RSS (`app/rss.xml/route.ts`)

Route Handler that builds a valid RSS 2.0 XML document from `getBlogPostList()`. Preserves the existing `/rss.xml` URL from the Gatsby site. Each `<item>` includes title, description (excerpt), pubDate, link, and guid.

### Sitemap (`app/sitemap.ts`)

Uses Next.js's built-in `sitemap.ts` file convention (produces `/sitemap.xml`). Covers:
- `/` — priority 1, monthly
- `/notebook` — priority 0.9, weekly
- `/about` — priority 0.5, yearly
- All 27 post slugs — priority 0.7, monthly; `lastModified` from `updated ?? date`

### Build output
```
Route (app)
├ ƒ /rss.xml         (dynamic route handler)
└ ○ /sitemap.xml     (static)
```

## Test plan

- [ ] `npm run build` succeeds (35 pages)
- [ ] `npm start` — visit `/rss.xml`: valid RSS 2.0 XML with 27 items
- [ ] Visit `/sitemap.xml`: valid XML listing all routes
- [ ] View source of any post page — confirm `og:title` and `twitter:title` match the post title
- [ ] View source of `/notebook` — confirm `<title>Notebook — Daniel W. Robert</title>`

https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11)_