### PR TITLE
Fix visual fidelity: restore missing global CSS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,3 +13,126 @@
   --font-serif: var(--font-ovo);
   --font-sans: var(--font-muli);
 }
+
+/* Base — the entire rem scale is built on 62.5% (1rem = 10px) */
+html {
+  box-sizing: border-box;
+  font-size: 62.5%;
+  line-height: 1.6;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  font-size: 2rem;
+  -webkit-font-smoothing: antialiased;
+}
+
+p {
+  margin: 0 0 2rem;
+}
+
+pre {
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  overflow-x: auto;
+}
+
+:not(pre) > code {
+  background-color: #282a36;
+  border-radius: 3px;
+  padding: 3px 5px;
+}
+
+img {
+  max-width: 100%;
+}
+
+/* Headings — restore visual hierarchy that Tailwind preflight removes */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #bcc2cd;
+  font-family: var(--font-ovo), serif;
+  margin: 0;
+}
+
+h1 { font-size: 4rem; }
+h2 { font-size: 3rem; }
+h3 { font-size: 2.4rem; }
+h4,
+h5,
+h6 { font-size: 1.6rem; }
+
+h1,
+h2,
+h3 {
+  color: #8be9fd;
+}
+
+.entry-title {
+  font-size: 4.5rem;
+  text-align: center;
+  line-height: 1.4;
+  margin: 0.9rem 0;
+}
+
+/* Links */
+a,
+a:link,
+a:visited {
+  color: #ff79c6;
+  text-decoration: none;
+  transition: color 0.5s;
+}
+
+header a,
+header a:link,
+header a:visited {
+  color: #bcc2cd;
+}
+
+header a:hover,
+header a.active {
+  color: #ff79c6;
+}
+
+a:hover {
+  color: #50fa7b;
+}
+
+/* Post cards */
+.note h2 a,
+.note h3 a {
+  color: #bd93f9;
+}
+
+.note {
+  background-color: #282a36;
+  border-radius: 0.4rem;
+  padding: 1.5rem 2rem;
+}
+
+.note:not(:last-of-type) {
+  margin-bottom: 4.5rem;
+}
+
+/* Post-page meta line */
+.entry-meta,
+.entry-meta-updated {
+  color: #bd93f9;
+  font-style: italic;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.entry-meta-updated {
+  color: #ffb86c;
+}


### PR DESCRIPTION
## Root cause

All 6 visual issues trace back to one missing declaration: `html { font-size: 62.5% }`. The entire Gatsby design uses a 10px rem base (62.5% of 16px), so every `rem` value in the codebase assumes `1rem = 10px`. Without that base rule, every rem rendered at `1rem = 16px` (browser default), causing a cascade of sizing problems:

| Issue | Without 62.5% | With 62.5% |
|---|---|---|
| Body text | 16px (too small) | 20px (`2rem`) ✓ |
| DWR logo | 40px (too large) | 25px (`2.5rem`) ✓ |
| Social icons | 51px (too large) | 32px (`3.2rem`) ✓ |
| Content max-width | 1264px (wrong) | 790px (`79rem`) ✓ |

The other missing rules caused the remaining issues:

- **No post card backgrounds** — `.note { background-color: #282a36 }` was absent
- **Titles/meta not centered** — `.entry-title { text-align: center }` and `.entry-meta { text-align: center }` were absent

## What changed

`app/globals.css` — single file change, all additions:

- `html { font-size: 62.5%; line-height: 1.6 }` — the foundational rem scale fix
- `body { font-size: 2rem }` — 20px body text
- `p`, `pre`, `:not(pre) > code`, `img` — element defaults
- `h1–h6` — Ovo font, Dracula colors, and explicit size scale to restore visual hierarchy (Tailwind preflight had reset all headings to `font-size: inherit`)
- Global link color rules — pink default, light gray in header, green on hover
- `.note` — dark `#282a36` background, border-radius, padding, 4.5rem spacing between cards
- `.entry-title` — 4.5rem, centered
- `.entry-meta` / `.entry-meta-updated` — centered, italic, purple/orange color

## Test plan

- [ ] `npm run dev` → home page: post cards have dark backgrounds, "Daniel W. Robert" title is centered and green, tagline is centered purple italic
- [ ] Notebook page: all post cards have dark backgrounds, h2 card titles are larger than body text
- [ ] Single post: title and date line are centered; section headings (h2/h3) inside the post body are visually larger than body text
- [ ] Header: DWR logo is ~25px (not 40px), nav links look proportional
- [ ] Footer: social icons are ~32px (not 51px)
- [ ] Layout content width is constrained to ~790px on wide screens
- [ ] `npm run test` — 6 Vitest tests pass

https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11)_