### PR TITLE
Add client-side site search (Fuse.js)

### DIFF
--- a/.claude/plans/202605-tailwind-font-sizing.md
+++ b/.claude/plans/202605-tailwind-font-sizing.md
@@ -1,0 +1,329 @@
+# Remove the `font-size: 62.5%` hack from `app/globals.css`
+
+## Context
+
+`app/globals.css` lines 18–23 set `html { font-size: 62.5% }` to make `1rem = 10px`. This was carried over from a pre-Tailwind iteration of the site so authoring rem values felt "natural" (`2rem` for body text, `4rem` for h1, etc.).
+
+The cost: **Tailwind's entire spacing/sizing scale gets multiplied by 0.625**. `p-4` produces 10px instead of 16px, `mb-6` produces 15px instead of 24px, `text-base` produces 10px instead of 16px, etc. Every utility class fights the design system. Authoring becomes guesswork ("how many `p-X` units do I want… in invisible 2.5px increments?"), and arbitrary rem values (`text-[2.5rem]`, `mb-[1.8rem]`, `px-[2rem]`) sprawl across components to compensate.
+
+Goal: drop the hack, restore Tailwind's canonical `1rem = 16px` baseline, and rewrite all custom CSS rules and arbitrary `[Xrem]` utilities so the site renders at roughly its current pixel sizes — but expressed via Tailwind's standard scale wherever possible.
+
+User decisions (confirmed):
+- **Hybrid: snap to Tailwind scale where it maps cleanly**, fall back to clean arbitrary rem values (`1.25rem`, `0.25rem`) only when the standard scale doesn't have a close enough stop. Slight visual drift on a few sizes is acceptable.
+- **Leave `resources/dwr-gatsby/` alone.** It's an archived snapshot and isn't part of the Next.js build.
+
+## Conversion reference
+
+After removal, `1rem = 16px`, so to preserve current rendering we multiply each existing rem value by `0.625`. Tailwind v4's `--spacing` unit is `0.25rem` (= 4px), so every step in the standard scale is 4px (`p-1 = 4px`, `p-2 = 8px`, … `p-10 = 40px`).
+
+Key mappings used throughout the migration:
+
+| Current rem (with hack) | Current px | New target | Method |
+|---|---|---|---|
+| `2rem` | 20px | `1.25rem` / `text-xl` / `mb-5` | exact |
+| `1.6rem` | 16px | `1rem` / `text-base` / `mb-4` | exact |
+| `1.5rem` | 15px | `1rem` (16px) / `mb-4` | snap (+1px) |
+| `2.4rem` | 24px | `1.5rem` / `text-2xl` / `mb-6` | exact |
+| `3rem` | 30px | `1.875rem` / `text-3xl` / `mb-7.5` | exact |
+| `4rem` | 40px | `2.5rem` / `mb-10` | exact |
+| `4.5rem` | 45px | `text-5xl` (3rem = 48px) / `mb-11` (44px) / `mb-12` (48px) | snap (±3px) |
+| `1.8rem` | 18px | `1.125rem` / `mb-4.5` | exact (Tailwind v4 supports half-steps) |
+| `2.5rem` | 25px | `1.5rem` (24px) / `mb-6` | snap (−1px) |
+| `0.5rem` | 5px | `0.3125rem` (5px) / `rounded-sm` (≈4px) | snap |
+| `0.4rem` | 4px | `rounded-sm` (4px) / `0.25rem` | exact |
+| `0.6rem` | 6px | `1.5` step (6px) | exact |
+| `5.5rem` | 55px | `mt-14` (56px) | snap (+1px) |
+| `3.2rem` | 32px | `w-8 h-8` (32px) | exact |
+| `2.4rem` (icon) | 24px | `w-6 h-6` (24px) | exact |
+| `1.6rem` (icon) | 16px | `w-4 h-4` (16px) | exact |
+| `18rem` (search box) | 180px | `w-[180px]` or `w-44` (176px) | snap or fixed px |
+| `79rem` (max-w) | 790px | `max-w-[49.375rem]` (790px) — keep as fixed px-equivalent | exact |
+
+For the existing standard utilities already in the JSX (e.g. `p-10`, `mb-6`, `py-28`, `pl-4`, `mr-8`), the hack also currently shrinks them by 0.625×. They need to be downsized after the fix to retain current visual rendering:
+
+| Current utility | Current px (with hack) | Replacement | New px |
+|---|---|---|---|
+| `p-10` (header/footer/nav overlay) | 25px | `p-6` | 24px |
+| `py-28` (Layout) | 70px | `py-18` | 72px |
+| `px-10` (Layout) | 25px | `px-6` | 24px |
+| `mb-6` (h3, p) | 15px | `mb-4` | 16px |
+| `mb-4` (h5) | 10px | `mb-2.5` | 10px |
+| `mt-6` (SocialLinks) | 15px | `mt-4` | 16px |
+| `mr-8` (footer/social) | 20px | `mr-5` | 20px |
+| `py-4` (Button, Search input) | 10px | `py-2.5` | 10px |
+| `px-6` (Button) | 15px | `px-4` | 16px |
+| `pl-4` (Search input) | 10px | `pl-2.5` | 10px |
+| `pr-12` (Search input) | 30px | `pr-7.5` | 30px |
+| `mt-2` (search dropdown) | 5px | `mt-1` | 4px |
+| `p-6` (TOC) | 15px | `p-4` | 16px |
+| `w-136` (search dropdown) | unclear (likely intentional fixed width) | leave as-is or convert to `w-[34rem]` | verify visually |
+
+## Files to modify
+
+### 1. `app/globals.css`
+
+Replace the base layer entirely. Final content for `@layer base`:
+
+```css
+@layer base {
+  html {
+    box-sizing: border-box;
+    line-height: 1.6;
+  }
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: inherit;
+  }
+
+  body {
+    font-size: 1.25rem; /* 20px — base body text */
+    -webkit-font-smoothing: antialiased;
+  }
+
+  p {
+    margin: 0 0 1.25rem; /* 20px */
+  }
+
+  pre {
+    border-radius: 0.3125rem; /* 5px */
+    padding: 1rem;            /* 16px (was 15px) */
+    overflow-x: auto;
+  }
+
+  :not(pre) > code {
+    background-color: #282a36;
+    border-radius: 3px;
+    padding: 3px 5px;
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    color: #bcc2cd;
+    font-family: var(--font-ovo), serif;
+    margin: 0;
+  }
+
+  h1 { font-size: 2.5rem; }   /* 40px */
+  h2 { font-size: 1.875rem; } /* 30px (matches Tailwind text-3xl) */
+  h3 { font-size: 1.5rem; }   /* 24px (matches text-2xl) */
+  h4, h5, h6 { font-size: 1rem; } /* 16px (matches text-base) */
+
+  h1, h2, h3 {
+    color: #8be9fd;
+  }
+
+  .entry-title {
+    font-size: 3rem;       /* 48px (was 45px — matches text-5xl) */
+    text-align: center;
+    line-height: 1.4;
+    margin: 0.5625rem 0;   /* 9px */
+  }
+
+  /* Links — unchanged */
+  a, a:link, a:visited { color: #ff79c6; text-decoration: none; transition: color 0.5s; }
+  header a, header a:link, header a:visited { color: #bcc2cd; }
+  header a:hover, header a.active { color: #ff79c6; }
+  a:hover { color: #50fa7b; }
+
+  .note h2 a, .note h3 a { color: #bd93f9; }
+
+  .note {
+    background-color: #282a36;
+    border-radius: 0.25rem;       /* 4px */
+    padding: 1rem 1.25rem;        /* 16px 20px (was 15px 20px) */
+  }
+
+  .note:not(:last-of-type) {
+    margin-bottom: 3rem;          /* 48px (was 45px) */
+  }
+
+  .entry-meta,
+  .entry-meta-updated {
+    color: #bd93f9;
+    font-style: italic;
+    margin-bottom: 1rem;          /* 16px (was 15px) */
+    text-align: center;
+  }
+
+  .entry-meta-updated { color: #ffb86c; }
+
+  .search-input::placeholder { color: #bcc2cd; opacity: 1; }
+}
+```
+
+Key removals/changes:
+- Remove `font-size: 62.5%` from `html`.
+- All rem values rebased so that `1rem = 16px`, snapping to Tailwind-aligned values where they match.
+- Comment on line 18 ("the entire rem scale is built on 62.5%") deleted.
+
+### 2. `components/Layout/Layout.tsx` (line 3)
+
+```tsx
+<div className="max-w-[49.375rem] mx-auto px-6 py-18 w-full">
+```
+
+- `max-w-[79rem]` (was 790px) → `max-w-[49.375rem]` (790px exact). Optionally fold the canonical content width into the `@theme` block as `--container-content: 49.375rem` and use `max-w-content`, but that's a follow-up.
+- `px-10` (was 25px) → `px-6` (24px).
+- `py-28` (was 70px) → `py-18` (72px).
+
+### 3. `components/Header/Header.tsx` (line 8)
+
+```tsx
+<header className="bg-shadow shadow-[0_0.3125rem_0.625rem_0_rgba(0,0,0,0.15)] p-6">
+```
+
+- `shadow-[0_0.5rem_1rem_…]` → `shadow-[0_0.3125rem_0.625rem_…]` (5px 10px preserved).
+- `p-10` → `p-6` (24px ≈ original 25px).
+
+### 4. `components/Footer/Footer.tsx` (lines 5–6)
+
+```tsx
+<footer className="bg-shadow mt-auto p-6 sm:flex sm:items-center sm:justify-between">
+  <p className="m-0 mr-5">
+```
+
+- `p-10` → `p-6`.
+- `mr-8` → `mr-5` (20px exact).
+
+### 5. `components/SocialLinks/SocialLinks.tsx`
+
+```tsx
+<div className="flex mt-4 sm:mt-0">
+  …
+  <Twitter className="w-8 h-8" />
+  …
+  <GitHub className="w-8 h-8" />
+  …
+  <Rss className="w-8 h-8" />
+```
+
+- `mt-6` → `mt-4` (16px ≈ original 15px).
+- `mr-8` (×2) → `mr-5` (20px exact).
+- `w-[3.2rem] h-[3.2rem]` (×3) → `w-8 h-8` (32px exact).
+
+### 6. `components/Button/Button.tsx` (line 12)
+
+```tsx
+className="bg-highlight-2 !text-background rounded-sm block font-bold mt-14 mx-auto opacity-80 py-2.5 px-4 w-fit transition-opacity duration-500 hover:opacity-100"
+```
+
+- `rounded-[0.4rem]` → `rounded-sm` (4px).
+- `mt-[5.5rem]` (was 55px) → `mt-14` (56px, +1px).
+- `py-4` (was 10px) → `py-2.5` (10px exact).
+- `px-6` (was 15px) → `px-4` (16px, +1px).
+
+### 7. `components/Nav/Nav.tsx`
+
+Replace every arbitrary rem and over-sized utility:
+
+- Line 43: `text-[2.5rem] ml-[15px] mr-auto` → `text-2xl ml-[15px] mr-auto` (text-2xl = 24px ≈ 25px).
+- Line 64: `ml-[15px] w-[18rem]` → `ml-[15px] w-44` (176px ≈ 180px) **OR** `w-[180px]` for exact.
+- Line 74: `font-serif text-[2.5rem]` → `font-serif text-2xl`.
+- Line 81: `… p-[0.5rem]` → `… p-2` (8px ≈ 5px) — accept slight growth, hit area improves; or `p-[0.3125rem]` for exact 5px.
+- Line 83: `<Menu className="w-[2.4rem] h-[2.4rem]" />` → `<Menu className="w-6 h-6" />` (24px exact).
+- Line 89: `… p-10 …` → `… p-6 …` (overlay container).
+- Line 90: `mb-[3rem]` → `mb-7.5` (30px exact) **OR** `mb-8` (32px snap).
+- Line 94: `… p-[0.5rem]` → `p-2` (or `p-[0.3125rem]` for exact 5px).
+- Line 96: `<X className="w-[2.4rem] h-[2.4rem]" />` → `<X className="w-6 h-6" />`.
+- Line 101: `gap-[3rem] mb-[4rem]` → `gap-7.5 mb-10` (30px / 40px exact).
+- Line 115: `text-[3rem]` → `text-3xl` (30px exact).
+
+Note: `ml-[15px]` and `mx-[15px]` are pixel-literal and unaffected; leave them.
+
+### 8. `components/SearchBox/SearchBox.tsx`
+
+- Line 68: `… rounded-[0.4rem] pl-4 pr-12 py-4 text-[1.4rem] …` → `… rounded-sm pl-2.5 pr-7.5 py-2.5 text-sm …` (text-sm = 14px exact, rest exact).
+- Line 74: `right-[0.6rem]` → `right-1.5` (6px exact).
+- Line 76: `<X className="w-[1.6rem] h-[1.6rem]" />` → `<X className="w-4 h-4" />`.
+- Line 81: `mt-2 … rounded-[0.4rem] … w-136 … shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)]` → `mt-1 … rounded-sm … w-[34rem] … shadow-[0_0.3125rem_0.9375rem_0_rgba(0,0,0,0.4)]` (or keep `w-136` if it's intentional). Verify visually.
+- Line 90: `px-[1.5rem] py-[1rem]` → `px-4 py-2.5` (16px / 10px).
+- Line 93: `text-[1.4rem]` → `text-sm` (14px exact).
+
+### 9. `components/TOC/TOC.tsx` (line 3)
+
+```tsx
+<div className="bg-shadow rounded-sm p-4 my-[1.125rem]">
+```
+
+- `rounded-[0.5rem]` → `rounded-sm` (4px) **OR** `rounded-[0.3125rem]` (5px exact).
+- `p-6` (was 15px) → `p-4` (16px).
+- `my-[1.8rem]` (was 18px) → `my-[1.125rem]` (18px exact) **OR** `my-4.5` (18px exact, half-step).
+
+### 10. `components/Stitch/Stitch.tsx` (lines 11–12)
+
+```tsx
+width = '2.8125rem',
+margin = '0 auto 2.8125rem',
+```
+
+- `4.5rem` (was 45px) → `2.8125rem` (45px exact). The Stitch is an SVG separator with intentional sizing, so preserve exact pixels rather than snapping.
+- Verify no caller passes a custom `width`/`margin` prop assuming the old scale: `app/page.tsx:17` and `app/[slug]/page.tsx:53` both use the defaults — safe.
+
+### 11. `app/page.tsx` (lines 13–25)
+
+- Line 14: `mb-6` (was 15px) → `mb-4` (16px).
+- Line 25: `mb-[1.8rem]` (was 18px) → `mb-[1.125rem]` (18px) or `mb-4.5`.
+- Line 33: `mb-4` (was 10px) → `mb-2.5` (10px exact).
+
+### 12. `app/[slug]/page.tsx` (lines 54–57)
+
+```tsx
+<div className="bg-shadow rounded-sm px-5 py-4">
+  <MDXRemote source={content} components={COMPONENT_MAP} />
+</div>
+<hr className="mt-12 mb-6 opacity-50" />
+```
+
+- Line 54: `rounded-[0.4rem] px-[2rem] py-[1.5rem]` → `rounded-sm px-5 py-4` (px-5 = 20px exact, py-4 = 16px ≈ 15px).
+- Line 57: `mt-[4.5rem] mb-[2.5rem]` → `mt-12 mb-6` (48px ≈ 45px, 24px ≈ 25px).
+
+## Files NOT modified
+
+- `resources/dwr-gatsby/**` — archived; per user decision.
+- `lib/helpers/mdx-components.js` — only maps `<pre>` to `CodeSnippet`; unaffected.
+- `components/CodeSnippet/CodeSnippet.tsx` — uses `rounded-lg` (canonical Tailwind, no rem hack dependency).
+- Any module CSS files — none in active use depend on the hack.
+
+## Optional follow-up (out of scope)
+
+If we want the typography scale to be fully Tailwind v4 idiomatic, we could:
+1. Define `--text-entry-title`, etc. via `@theme inline` in `globals.css`.
+2. Replace the `h1`–`h6` rules with utility classes on each heading site (or keep base styles and just lean on Tailwind's `text-*` scale). This is a larger refactor; the current plan keeps the base-layer heading rules in CSS and just rebases their values.
+
+## Verification
+
+1. **Run the dev server**: `npm run dev`.
+2. **Walk every page** and visually compare against the current branch in another tab/window:
+   - `/` (homepage) — entry-title, h2 "Latest Notes:", note cards, Button.
+   - `/notebook` — listing of notes.
+   - `/about` — static content typography.
+   - `/[any-slug]` — full blog post (entry-title, entry-meta, MDX body, headings inside content, code blocks, TOC, hr separator, back button).
+   - 404 page.
+3. **Headers/footer**: confirm Header padding, logo size, nav link sizing/positioning, Footer padding and SocialLinks icon size.
+4. **Mobile (≤ sm breakpoint)**: open hamburger overlay, verify font sizes on overlay links, gap, close button, search box width/typography. Resize across breakpoints.
+5. **Search**: type a query, verify dropdown width, item padding, excerpt font size (14px), clear-X button positioning.
+6. **Code blocks** in a post: confirm `pre` padding/border-radius look right and that inline `code` chips still pad correctly.
+7. **Lint**: `npm run lint` — must pass.
+8. **Build**: `npm run build` — must succeed.
+9. **Browser DevTools spot-check** on a couple of elements: confirm computed pixel values match the table above (e.g. `body` should be 20px, `h1` 40px, `.entry-title` 48px, Layout `py` 72px).
+
+## Critical files (paths)
+
+- `app/globals.css`
+- `app/layout.tsx` (read-only; no changes needed)
+- `app/page.tsx`
+- `app/[slug]/page.tsx`
+- `components/Layout/Layout.tsx`
+- `components/Header/Header.tsx`
+- `components/Footer/Footer.tsx`
+- `components/Nav/Nav.tsx`
+- `components/SearchBox/SearchBox.tsx`
+- `components/Button/Button.tsx`
+- `components/SocialLinks/SocialLinks.tsx`
+- `components/Stitch/Stitch.tsx`
+- `components/TOC/TOC.tsx`

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -51,9 +51,7 @@ export default async function PostPage({ params }: Props) {
       <h1 className="entry-title text-highlight-3">{title}</h1>
       <p className={dateClass}>{dateLabel}</p>
       <Stitch />
-      <div className="bg-shadow rounded-[0.4rem] px-[2rem] py-[1.5rem]">
-        <MDXRemote source={content} components={COMPONENT_MAP} />
-      </div>
+      <MDXRemote source={content} components={COMPONENT_MAP} />
       <hr className="mt-[4.5rem] mb-[2.5rem] opacity-50" />
       <Button href="/notebook">&larr; Back to all notes</Button>
     </>

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -51,7 +51,9 @@ export default async function PostPage({ params }: Props) {
       <h1 className="entry-title text-highlight-3">{title}</h1>
       <p className={dateClass}>{dateLabel}</p>
       <Stitch />
-      <MDXRemote source={content} components={COMPONENT_MAP} />
+	  <div className="bg-shadow rounded-[0.4rem] px-[2rem] py-[1.5rem]">
+		<MDXRemote source={content} components={COMPONENT_MAP} />
+	  </div>
       <hr className="mt-[4.5rem] mb-[2.5rem] opacity-50" />
       <Button href="/notebook">&larr; Back to all notes</Button>
     </>

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -51,10 +51,10 @@ export default async function PostPage({ params }: Props) {
       <h1 className="entry-title text-highlight-3">{title}</h1>
       <p className={dateClass}>{dateLabel}</p>
       <Stitch />
-	  <div className="bg-shadow rounded-[0.4rem] px-[2rem] py-[1.5rem]">
+	  <div className="bg-shadow rounded-sm px-5 py-4">
 		<MDXRemote source={content} components={COMPONENT_MAP} />
 	  </div>
-      <hr className="mt-[4.5rem] mb-[2.5rem] opacity-50" />
+      <hr className="mt-12 mb-6 opacity-50" />
       <Button href="/notebook">&larr; Back to all notes</Button>
     </>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,10 +15,8 @@
 }
 
 @layer base {
-	/* Base — the entire rem scale is built on 62.5% (1rem = 10px) */
 	html {
 		box-sizing: border-box;
-		font-size: 62.5%;
 		line-height: 1.6;
 	}
 
@@ -29,17 +27,17 @@
 	}
 
 	body {
-		font-size: 2rem;
+		font-size: 1.25rem; /* 20px */
 		-webkit-font-smoothing: antialiased;
 	}
 
 	p {
-		margin: 0 0 2rem;
+		margin: 0 0 1.25rem;
 	}
 
 	pre {
-		border-radius: 0.5rem;
-		padding: 1.5rem;
+		border-radius: 0.3125rem;
+		padding: 1rem;
 		overflow-x: auto;
 	}
 
@@ -65,12 +63,12 @@
 		margin: 0;
 	}
 
-	h1 { font-size: 4rem; }
-	h2 { font-size: 3rem; }
-	h3 { font-size: 2.4rem; }
+	h1 { font-size: 2.5rem; }    /* 40px */
+	h2 { font-size: 1.875rem; }  /* 30px */
+	h3 { font-size: 1.5rem; }    /* 24px */
 	h4,
 	h5,
-	h6 { font-size: 1.6rem; }
+	h6 { font-size: 1rem; }      /* 16px */
 
 	h1,
 	h2,
@@ -79,10 +77,10 @@
 	}
 
 	.entry-title {
-		font-size: 4.5rem;
+		font-size: 3rem; /* 48px */
 		text-align: center;
 		line-height: 1.4;
-		margin: 0.9rem 0;
+		margin: 0.5625rem 0; /* 9px */
 	}
 
 	/* Links */
@@ -117,12 +115,12 @@
 
 	.note {
 		background-color: #282a36;
-		border-radius: 0.4rem;
-		padding: 1.5rem 2rem;
+		border-radius: 0.25rem;
+		padding: 1rem 1.25rem;
 	}
 
 	.note:not(:last-of-type) {
-		margin-bottom: 4.5rem;
+		margin-bottom: 3rem; /* 48px */
 	}
 
 	/* Post-page meta line */
@@ -130,7 +128,7 @@
 	.entry-meta-updated {
 		color: #bd93f9;
 		font-style: italic;
-		margin-bottom: 1.5rem;
+		margin-bottom: 1rem;
 		text-align: center;
 	}
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,134 +14,131 @@
   --font-sans: var(--font-muli);
 }
 
-@layer base {
-	/* Base — the entire rem scale is built on 62.5% (1rem = 10px) */
-	html {
-		box-sizing: border-box;
-		font-size: 62.5%;
-		line-height: 1.6;
-	}
-
-	*,
-	*:before,
-	*:after {
-		box-sizing: inherit;
-	}
-
-	body {
-		font-size: 2rem;
-		-webkit-font-smoothing: antialiased;
-	}
-
-	p {
-		margin: 0 0 2rem;
-	}
-
-	pre {
-		border-radius: 0.5rem;
-		padding: 1.5rem;
-		overflow-x: auto;
-	}
-
-	:not(pre) > code {
-		background-color: #282a36;
-		border-radius: 3px;
-		padding: 3px 5px;
-	}
-
-	img {
-		max-width: 100%;
-	}
-
-	/* Headings — restore visual hierarchy that Tailwind preflight removes */
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		color: #bcc2cd;
-		font-family: var(--font-ovo), serif;
-		margin: 0;
-	}
-
-	h1 { font-size: 4rem; }
-	h2 { font-size: 3rem; }
-	h3 { font-size: 2.4rem; }
-	h4,
-	h5,
-	h6 { font-size: 1.6rem; }
-
-	h1,
-	h2,
-	h3 {
-		color: #8be9fd;
-	}
-
-	.entry-title {
-		font-size: 4.5rem;
-		text-align: center;
-		line-height: 1.4;
-		margin: 0.9rem 0;
-	}
-
-	/* Links */
-	a,
-	a:link,
-	a:visited {
-		color: #ff79c6;
-		text-decoration: none;
-		transition: color 0.5s;
-	}
-
-	header a,
-	header a:link,
-	header a:visited {
-		color: #bcc2cd;
-	}
-
-	header a:hover,
-	header a.active {
-		color: #ff79c6;
-	}
-
-	a:hover {
-		color: #50fa7b;
-	}
-
-	/* Post cards */
-	.note h2 a,
-	.note h3 a {
-		color: #bd93f9;
-	}
-
-	.note {
-		background-color: #282a36;
-		border-radius: 0.4rem;
-		padding: 1.5rem 2rem;
-	}
-
-	.note:not(:last-of-type) {
-		margin-bottom: 4.5rem;
-	}
-
-	/* Post-page meta line */
-	.entry-meta,
-	.entry-meta-updated {
-		color: #bd93f9;
-		font-style: italic;
-		margin-bottom: 1.5rem;
-		text-align: center;
-	}
-
-	.entry-meta-updated {
-		color: #ffb86c;
-	}
-
-	/* Search */
-	.search-input::placeholder {
-		color: #bcc2cd;
-		opacity: 1;
-	}
+/* Base — the entire rem scale is built on 62.5% (1rem = 10px) */
+html {
+  box-sizing: border-box;
+  font-size: 62.5%;
+  line-height: 1.6;
 }
 
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  font-size: 2rem;
+  -webkit-font-smoothing: antialiased;
+}
+
+p {
+  margin: 0 0 2rem;
+}
+
+pre {
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  overflow-x: auto;
+}
+
+:not(pre) > code {
+  background-color: #282a36;
+  border-radius: 3px;
+  padding: 3px 5px;
+}
+
+img {
+  max-width: 100%;
+}
+
+/* Headings — restore visual hierarchy that Tailwind preflight removes */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #bcc2cd;
+  font-family: var(--font-ovo), serif;
+  margin: 0;
+}
+
+h1 { font-size: 4rem; }
+h2 { font-size: 3rem; }
+h3 { font-size: 2.4rem; }
+h4,
+h5,
+h6 { font-size: 1.6rem; }
+
+h1,
+h2,
+h3 {
+  color: #8be9fd;
+}
+
+.entry-title {
+  font-size: 4.5rem;
+  text-align: center;
+  line-height: 1.4;
+  margin: 0.9rem 0;
+}
+
+/* Links */
+a,
+a:link,
+a:visited {
+  color: #ff79c6;
+  text-decoration: none;
+  transition: color 0.5s;
+}
+
+header a,
+header a:link,
+header a:visited {
+  color: #bcc2cd;
+}
+
+header a:hover,
+header a.active {
+  color: #ff79c6;
+}
+
+a:hover {
+  color: #50fa7b;
+}
+
+/* Post cards */
+.note h2 a,
+.note h3 a {
+  color: #bd93f9;
+}
+
+.note {
+  background-color: #282a36;
+  border-radius: 0.4rem;
+  padding: 1.5rem 2rem;
+}
+
+.note:not(:last-of-type) {
+  margin-bottom: 4.5rem;
+}
+
+/* Post-page meta line */
+.entry-meta,
+.entry-meta-updated {
+  color: #bd93f9;
+  font-style: italic;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.entry-meta-updated {
+  color: #ffb86c;
+}
+
+/* Search */
+.search-input::placeholder {
+  color: #bcc2cd;
+  opacity: 1;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,131 +14,133 @@
   --font-sans: var(--font-muli);
 }
 
-/* Base — the entire rem scale is built on 62.5% (1rem = 10px) */
-html {
-  box-sizing: border-box;
-  font-size: 62.5%;
-  line-height: 1.6;
-}
+@layer base {
+	/* Base — the entire rem scale is built on 62.5% (1rem = 10px) */
+	html {
+	box-sizing: border-box;
+	font-size: 62.5%;
+	line-height: 1.6;
+	}
 
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}
+	*,
+	*:before,
+	*:after {
+	box-sizing: inherit;
+	}
 
-body {
-  font-size: 2rem;
-  -webkit-font-smoothing: antialiased;
-}
+	body {
+	font-size: 2rem;
+	-webkit-font-smoothing: antialiased;
+	}
 
-p {
-  margin: 0 0 2rem;
-}
+	p {
+	margin: 0 0 2rem;
+	}
 
-pre {
-  border-radius: 0.5rem;
-  padding: 1.5rem;
-  overflow-x: auto;
-}
+	pre {
+	border-radius: 0.5rem;
+	padding: 1.5rem;
+	overflow-x: auto;
+	}
 
-:not(pre) > code {
-  background-color: #282a36;
-  border-radius: 3px;
-  padding: 3px 5px;
-}
+	:not(pre) > code {
+	background-color: #282a36;
+	border-radius: 3px;
+	padding: 3px 5px;
+	}
 
-img {
-  max-width: 100%;
-}
+	img {
+	max-width: 100%;
+	}
 
-/* Headings — restore visual hierarchy that Tailwind preflight removes */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: #bcc2cd;
-  font-family: var(--font-ovo), serif;
-  margin: 0;
-}
+	/* Headings — restore visual hierarchy that Tailwind preflight removes */
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+	color: #bcc2cd;
+	font-family: var(--font-ovo), serif;
+	margin: 0;
+	}
 
-h1 { font-size: 4rem; }
-h2 { font-size: 3rem; }
-h3 { font-size: 2.4rem; }
-h4,
-h5,
-h6 { font-size: 1.6rem; }
+	h1 { font-size: 4rem; }
+	h2 { font-size: 3rem; }
+	h3 { font-size: 2.4rem; }
+	h4,
+	h5,
+	h6 { font-size: 1.6rem; }
 
-h1,
-h2,
-h3 {
-  color: #8be9fd;
-}
+	h1,
+	h2,
+	h3 {
+	color: #8be9fd;
+	}
 
-.entry-title {
-  font-size: 4.5rem;
-  text-align: center;
-  line-height: 1.4;
-  margin: 0.9rem 0;
-}
+	.entry-title {
+	font-size: 4.5rem;
+	text-align: center;
+	line-height: 1.4;
+	margin: 0.9rem 0;
+	}
 
-/* Links */
-a,
-a:link,
-a:visited {
-  color: #ff79c6;
-  text-decoration: none;
-  transition: color 0.5s;
-}
+	/* Links */
+	a,
+	a:link,
+	a:visited {
+	color: #ff79c6;
+	text-decoration: none;
+	transition: color 0.5s;
+	}
 
-header a,
-header a:link,
-header a:visited {
-  color: #bcc2cd;
-}
+	header a,
+	header a:link,
+	header a:visited {
+	color: #bcc2cd;
+	}
 
-header a:hover,
-header a.active {
-  color: #ff79c6;
-}
+	header a:hover,
+	header a.active {
+	color: #ff79c6;
+	}
 
-a:hover {
-  color: #50fa7b;
-}
+	a:hover {
+	color: #50fa7b;
+	}
 
-/* Post cards */
-.note h2 a,
-.note h3 a {
-  color: #bd93f9;
-}
+	/* Post cards */
+	.note h2 a,
+	.note h3 a {
+	color: #bd93f9;
+	}
 
-.note {
-  background-color: #282a36;
-  border-radius: 0.4rem;
-  padding: 1.5rem 2rem;
-}
+	.note {
+	background-color: #282a36;
+	border-radius: 0.4rem;
+	padding: 1.5rem 2rem;
+	}
 
-.note:not(:last-of-type) {
-  margin-bottom: 4.5rem;
-}
+	.note:not(:last-of-type) {
+	margin-bottom: 4.5rem;
+	}
 
-/* Post-page meta line */
-.entry-meta,
-.entry-meta-updated {
-  color: #bd93f9;
-  font-style: italic;
-  margin-bottom: 1.5rem;
-  text-align: center;
-}
+	/* Post-page meta line */
+	.entry-meta,
+	.entry-meta-updated {
+	color: #bd93f9;
+	font-style: italic;
+	margin-bottom: 1.5rem;
+	text-align: center;
+	}
 
-.entry-meta-updated {
-  color: #ffb86c;
-}
+	.entry-meta-updated {
+	color: #ffb86c;
+	}
 
-/* Search */
-.search-input::placeholder {
-  color: #bcc2cd;
-  opacity: 1;
+	/* Search */
+	.search-input::placeholder {
+	color: #bcc2cd;
+	opacity: 1;
+	}
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -137,4 +137,11 @@
 	.entry-meta-updated {
 		color: #ffb86c;
 	}
+
+	/* Search */
+	.search-input::placeholder {
+		color: #bcc2cd;
+		opacity: 1;
+	}
 }
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,40 +17,40 @@
 @layer base {
 	/* Base — the entire rem scale is built on 62.5% (1rem = 10px) */
 	html {
-	box-sizing: border-box;
-	font-size: 62.5%;
-	line-height: 1.6;
+		box-sizing: border-box;
+		font-size: 62.5%;
+		line-height: 1.6;
 	}
 
 	*,
 	*:before,
 	*:after {
-	box-sizing: inherit;
+		box-sizing: inherit;
 	}
 
 	body {
-	font-size: 2rem;
-	-webkit-font-smoothing: antialiased;
+		font-size: 2rem;
+		-webkit-font-smoothing: antialiased;
 	}
 
 	p {
-	margin: 0 0 2rem;
+		margin: 0 0 2rem;
 	}
 
 	pre {
-	border-radius: 0.5rem;
-	padding: 1.5rem;
-	overflow-x: auto;
+		border-radius: 0.5rem;
+		padding: 1.5rem;
+		overflow-x: auto;
 	}
 
 	:not(pre) > code {
-	background-color: #282a36;
-	border-radius: 3px;
-	padding: 3px 5px;
+		background-color: #282a36;
+		border-radius: 3px;
+		padding: 3px 5px;
 	}
 
 	img {
-	max-width: 100%;
+		max-width: 100%;
 	}
 
 	/* Headings — restore visual hierarchy that Tailwind preflight removes */
@@ -60,9 +60,9 @@
 	h4,
 	h5,
 	h6 {
-	color: #bcc2cd;
-	font-family: var(--font-ovo), serif;
-	margin: 0;
+		color: #bcc2cd;
+		font-family: var(--font-ovo), serif;
+		margin: 0;
 	}
 
 	h1 { font-size: 4rem; }
@@ -75,72 +75,72 @@
 	h1,
 	h2,
 	h3 {
-	color: #8be9fd;
+		color: #8be9fd;
 	}
 
 	.entry-title {
-	font-size: 4.5rem;
-	text-align: center;
-	line-height: 1.4;
-	margin: 0.9rem 0;
+		font-size: 4.5rem;
+		text-align: center;
+		line-height: 1.4;
+		margin: 0.9rem 0;
 	}
 
 	/* Links */
 	a,
 	a:link,
 	a:visited {
-	color: #ff79c6;
-	text-decoration: none;
-	transition: color 0.5s;
+		color: #ff79c6;
+		text-decoration: none;
+		transition: color 0.5s;
 	}
 
 	header a,
 	header a:link,
 	header a:visited {
-	color: #bcc2cd;
+		color: #bcc2cd;
 	}
 
 	header a:hover,
 	header a.active {
-	color: #ff79c6;
+		color: #ff79c6;
 	}
 
 	a:hover {
-	color: #50fa7b;
+		color: #50fa7b;
 	}
 
 	/* Post cards */
 	.note h2 a,
 	.note h3 a {
-	color: #bd93f9;
+		color: #bd93f9;
 	}
 
 	.note {
-	background-color: #282a36;
-	border-radius: 0.4rem;
-	padding: 1.5rem 2rem;
+		background-color: #282a36;
+		border-radius: 0.4rem;
+		padding: 1.5rem 2rem;
 	}
 
 	.note:not(:last-of-type) {
-	margin-bottom: 4.5rem;
+		margin-bottom: 4.5rem;
 	}
 
 	/* Post-page meta line */
 	.entry-meta,
 	.entry-meta-updated {
-	color: #bd93f9;
-	font-style: italic;
-	margin-bottom: 1.5rem;
-	text-align: center;
+		color: #bd93f9;
+		font-style: italic;
+		margin-bottom: 1.5rem;
+		text-align: center;
 	}
 
 	.entry-meta-updated {
-	color: #ffb86c;
+		color: #ffb86c;
 	}
 
 	/* Search */
 	.search-input::placeholder {
-	color: #bcc2cd;
-	opacity: 1;
+		color: #bcc2cd;
+		opacity: 1;
 	}
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default async function Home() {
   return (
     <>
       <h1 className="entry-title text-highlight-3">Daniel W. Robert</h1>
-      <h3 className="text-highlight-1 italic mb-6 text-center">
+      <h3 className="text-highlight-1 italic mb-4 text-center">
         Front-End Engineer. Always a student.
       </h3>
       <Stitch />
@@ -22,7 +22,7 @@ export default async function Home() {
         WordPress.com, Jetpack, WooCommerce, Tumblr, Gravatar, and a bunch of
         other cool products that you may have seen around the web.
       </p>
-      <h2 className="mb-[1.8rem]">Latest Notes:</h2>
+      <h2 className="mb-[1.125rem]">Latest Notes:</h2>
       {latestPosts.map((post) => (
         <article className="note" key={post.slug}>
           <h3>
@@ -30,7 +30,7 @@ export default async function Home() {
               {post.title}
             </Link>
           </h3>
-          <h5 className="italic mb-4">
+          <h5 className="italic mb-2.5">
             {format(parseISO(post.date), "MM/dd/yyyy")}
           </h5>
           <p>{post.excerpt}</p>

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -9,7 +9,7 @@ export default function Button({ href, children }: ButtonProps) {
   return (
     <Link
       href={href}
-      className="bg-highlight-2 !text-background rounded-[0.4rem] block font-bold mt-[5.5rem] mx-auto opacity-80 py-4 px-6 w-fit transition-opacity duration-500 hover:opacity-100"
+      className="bg-highlight-2 !text-background rounded-sm block font-bold mt-14 mx-auto opacity-80 py-2.5 px-4 w-fit transition-opacity duration-500 hover:opacity-100"
     >
       {children}
     </Link>

--- a/components/CodeSnippet/CodeSnippet.tsx
+++ b/components/CodeSnippet/CodeSnippet.tsx
@@ -6,7 +6,7 @@ export default function CodeSnippet(props: React.ComponentProps<typeof Code>) {
     <Code
       {...props}
       theme={draculaTheme}
-      className="rounded-lg overflow-x-auto"
+      className="rounded-lg overflow-x-auto text-base"
     />
   );
 }

--- a/components/CodeSnippet/CodeSnippet.tsx
+++ b/components/CodeSnippet/CodeSnippet.tsx
@@ -6,7 +6,7 @@ export default function CodeSnippet(props: React.ComponentProps<typeof Code>) {
     <Code
       {...props}
       theme={draculaTheme}
-      className="rounded-lg overflow-x-auto text-base"
+      className="rounded-lg overflow-x-auto"
     />
   );
 }

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -2,8 +2,8 @@ import SocialLinks from '@/components/SocialLinks/SocialLinks';
 
 export default function Footer() {
   return (
-    <footer className="bg-shadow mt-auto p-10 sm:flex sm:items-center sm:justify-between">
-      <p className="m-0 mr-8">
+    <footer className="bg-shadow mt-auto p-6 sm:flex sm:items-center sm:justify-between">
+      <p className="m-0 mr-5">
         Copyright &copy; {new Date().getFullYear()} Daniel W Robert. All rights reserved.
       </p>
       <SocialLinks />

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { getBlogPostList } from "@/lib/helpers/file-helpers";
 import Nav from "@/components/Nav/Nav";
-import SearchBox from "@/components/SearchBox/SearchBox";
 
 export default async function Header() {
   const posts = await getBlogPostList();
@@ -8,16 +7,12 @@ export default async function Header() {
   return (
     <header className="bg-shadow shadow-[0_0.5rem_1rem_0_rgba(0,0,0,0.15)] p-10">
       <Nav
-        searchSlot={
-          <SearchBox
-            posts={posts.map(({ slug, title, excerpt, tags }) => ({
-              slug,
-              title,
-              excerpt,
-              tags,
-            }))}
-          />
-        }
+        posts={posts.map(({ slug, title, excerpt, tags }) => ({
+          slug,
+          title,
+          excerpt,
+          tags,
+        }))}
       />
     </header>
   );

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -5,7 +5,7 @@ export default async function Header() {
   const posts = await getBlogPostList();
 
   return (
-    <header className="bg-shadow shadow-[0_0.5rem_1rem_0_rgba(0,0,0,0.15)] p-10">
+    <header className="bg-shadow shadow-[0_0.3125rem_0.625rem_0_rgba(0,0,0,0.15)] p-6">
       <Nav
         posts={posts.map(({ slug, title, excerpt, tags }) => ({
           slug,

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,9 +1,24 @@
-import Nav from '@/components/Nav/Nav';
+import { getBlogPostList } from "@/lib/helpers/file-helpers";
+import Nav from "@/components/Nav/Nav";
+import SearchBox from "@/components/SearchBox/SearchBox";
 
-export default function Header() {
+export default async function Header() {
+  const posts = await getBlogPostList();
+
   return (
     <header className="bg-shadow shadow-[0_0.5rem_1rem_0_rgba(0,0,0,0.15)] p-10">
-      <Nav />
+      <Nav
+        searchSlot={
+          <SearchBox
+            posts={posts.map(({ slug, title, excerpt, tags }) => ({
+              slug,
+              title,
+              excerpt,
+              tags,
+            }))}
+          />
+        }
+      />
     </header>
   );
 }

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="max-w-[79rem] mx-auto px-10 py-28 w-full">
+    <div className="max-w-[49.375rem] mx-auto px-6 py-18 w-full">
       {children}
     </div>
   );

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-export default function Nav() {
+export default function Nav({ searchSlot }: { searchSlot?: React.ReactNode }) {
   const pathname = usePathname();
 
   return (
@@ -30,6 +30,7 @@ export default function Nav() {
             About
           </Link>
         </li>
+        {searchSlot && <li className="ml-[15px]">{searchSlot}</li>}
       </ul>
     </nav>
   );

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -40,7 +40,7 @@ export default function Nav({ posts = [] }: { posts?: Post[] }) {
       {/* ── Desktop nav (hidden on mobile) ─────────────────────── */}
       <nav className="hidden sm:block">
         <ul className="flex flex-row items-center list-none m-0 p-0">
-          <li className="font-serif text-[2.5rem] ml-[15px] mr-auto">
+          <li className="font-serif text-2xl ml-[15px] mr-auto">
             <Link href="/" className={pathname === "/" ? "active" : ""}>
               DWR
             </Link>
@@ -61,7 +61,7 @@ export default function Nav({ posts = [] }: { posts?: Post[] }) {
               About
             </Link>
           </li>
-          <li className="ml-[15px] w-[18rem]">
+          <li className="ml-[15px] w-[180px]">
             <SearchBox posts={posts} />
           </li>
         </ul>
@@ -71,34 +71,34 @@ export default function Nav({ posts = [] }: { posts?: Post[] }) {
       <div className="flex sm:hidden items-center justify-between">
         <Link
           href="/"
-          className={`font-serif text-[2.5rem]${pathname === "/" ? " active" : ""}`}
+          className={`font-serif text-2xl${pathname === "/" ? " active" : ""}`}
         >
           DWR
         </Link>
         <button
           onClick={() => setMobileOpen(true)}
           aria-label="Open navigation menu"
-          className="text-shadow-light hover:text-highlight-2 transition-colors duration-500 p-[0.5rem]"
+          className="text-shadow-light hover:text-highlight-2 transition-colors duration-500 p-1.5"
         >
-          <Menu className="w-[2.4rem] h-[2.4rem]" />
+          <Menu className="w-6 h-6" />
         </button>
       </div>
 
       {/* ── Mobile overlay ─────────────────────────────────────── */}
       {mobileOpen && (
-        <div className="fixed inset-0 bg-shadow z-50 flex flex-col p-10 overflow-y-auto">
-          <div className="flex justify-end mb-[3rem]">
+        <div className="fixed inset-0 bg-shadow z-50 flex flex-col p-6 overflow-y-auto">
+          <div className="flex justify-end mb-7.5">
             <button
               onClick={() => setMobileOpen(false)}
               aria-label="Close navigation menu"
-              className="border border-shadow-light text-shadow-light hover:text-highlight-2 hover:border-highlight-2 transition-colors duration-500 p-[0.5rem]"
+              className="border border-shadow-light text-shadow-light hover:text-highlight-2 hover:border-highlight-2 transition-colors duration-500 p-1.5"
             >
-              <X className="w-[2.4rem] h-[2.4rem]" />
+              <X className="w-6 h-6" />
             </button>
           </div>
 
           <nav>
-            <ul className="list-none p-0 m-0 flex flex-col gap-[3rem] mb-[4rem]">
+            <ul className="list-none p-0 m-0 flex flex-col gap-7.5 mb-10">
               {[
                 { href: "/", label: "Home", active: pathname === "/" },
                 {
@@ -112,7 +112,7 @@ export default function Nav({ posts = [] }: { posts?: Post[] }) {
                   <Link
                     href={href}
                     onClick={() => setMobileOpen(false)}
-                    className={`text-[3rem] block transition-colors duration-500 ${
+                    className={`text-3xl block transition-colors duration-500 ${
                       active
                         ? "text-highlight-2"
                         : "text-shadow-light hover:text-highlight-2"

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -1,37 +1,133 @@
 "use client";
 
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "react-feather";
+import SearchBox from "@/components/SearchBox/SearchBox";
 
-export default function Nav({ searchSlot }: { searchSlot?: React.ReactNode }) {
+type Post = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  tags?: string[];
+};
+
+export default function Nav({ posts = [] }: { posts?: Post[] }) {
   const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  // Lock body scroll while overlay is open
+  useEffect(() => {
+    document.body.style.overflow = mobileOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [mobileOpen]);
+
+  // Dismiss on Escape
+  useEffect(() => {
+    if (!mobileOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setMobileOpen(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [mobileOpen]);
 
   return (
-    <nav>
-      <ul className="flex flex-row items-center list-none m-0 p-0">
-        <li className="font-serif text-[2.5rem] ml-[15px] mr-auto">
-          <Link href="/" className={pathname === '/' ? 'active' : ''}>
-            DWR
-          </Link>
-        </li>
-        <li className="mx-[15px]">
-          <Link
-            href="/notebook"
-            className={pathname?.startsWith('/notebook') ? 'active' : ''}
-          >
-            Notebook
-          </Link>
-        </li>
-        <li className="mx-[15px]">
-          <Link
-            href="/about"
-            className={pathname === '/about' ? 'active' : ''}
-          >
-            About
-          </Link>
-        </li>
-        {searchSlot && <li className="ml-[15px]">{searchSlot}</li>}
-      </ul>
-    </nav>
+    <>
+      {/* ── Desktop nav (hidden on mobile) ─────────────────────── */}
+      <nav className="hidden sm:block">
+        <ul className="flex flex-row items-center list-none m-0 p-0">
+          <li className="font-serif text-[2.5rem] ml-[15px] mr-auto">
+            <Link href="/" className={pathname === "/" ? "active" : ""}>
+              DWR
+            </Link>
+          </li>
+          <li className="mx-[15px]">
+            <Link
+              href="/notebook"
+              className={pathname?.startsWith("/notebook") ? "active" : ""}
+            >
+              Notebook
+            </Link>
+          </li>
+          <li className="mx-[15px]">
+            <Link
+              href="/about"
+              className={pathname === "/about" ? "active" : ""}
+            >
+              About
+            </Link>
+          </li>
+          <li className="ml-[15px] w-[18rem]">
+            <SearchBox posts={posts} />
+          </li>
+        </ul>
+      </nav>
+
+      {/* ── Mobile bar (logo + hamburger) ──────────────────────── */}
+      <div className="flex sm:hidden items-center justify-between">
+        <Link
+          href="/"
+          className={`font-serif text-[2.5rem]${pathname === "/" ? " active" : ""}`}
+        >
+          DWR
+        </Link>
+        <button
+          onClick={() => setMobileOpen(true)}
+          aria-label="Open navigation menu"
+          className="text-shadow-light hover:text-highlight-2 transition-colors duration-500 p-[0.5rem]"
+        >
+          <Menu className="w-[2.4rem] h-[2.4rem]" />
+        </button>
+      </div>
+
+      {/* ── Mobile overlay ─────────────────────────────────────── */}
+      {mobileOpen && (
+        <div className="fixed inset-0 bg-shadow z-50 flex flex-col p-10 overflow-y-auto">
+          <div className="flex justify-end mb-[3rem]">
+            <button
+              onClick={() => setMobileOpen(false)}
+              aria-label="Close navigation menu"
+              className="border border-shadow-light text-shadow-light hover:text-highlight-2 hover:border-highlight-2 transition-colors duration-500 p-[0.5rem]"
+            >
+              <X className="w-[2.4rem] h-[2.4rem]" />
+            </button>
+          </div>
+
+          <nav>
+            <ul className="list-none p-0 m-0 flex flex-col gap-[3rem] mb-[4rem]">
+              {[
+                { href: "/", label: "Home", active: pathname === "/" },
+                {
+                  href: "/notebook",
+                  label: "Notebook",
+                  active: !!pathname?.startsWith("/notebook"),
+                },
+                { href: "/about", label: "About", active: pathname === "/about" },
+              ].map(({ href, label, active }) => (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    onClick={() => setMobileOpen(false)}
+                    className={`text-[3rem] block transition-colors duration-500 ${
+                      active
+                        ? "text-highlight-2"
+                        : "text-shadow-light hover:text-highlight-2"
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          <SearchBox posts={posts} />
+        </div>
+      )}
+    </>
   );
 }

--- a/components/SearchBox/SearchBox.tsx
+++ b/components/SearchBox/SearchBox.tsx
@@ -65,20 +65,20 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
           onKeyDown={(e) => {
             if (e.key === "Escape") close();
           }}
-          className="search-input bg-background text-text rounded-[0.4rem] pl-4 pr-12 py-4 text-[1.4rem] outline-none border-0 w-full"
+          className="search-input bg-background text-text rounded-sm pl-2.5 pr-7.5 py-2.5 text-sm outline-none border-0 w-full"
         />
         {query && (
           <button
             onClick={close}
             aria-label="Clear search"
-            className="absolute right-[0.6rem] top-1/2 -translate-y-1/2 text-shadow-light hover:text-highlight-2 transition-colors duration-500"
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-shadow-light hover:text-highlight-2 transition-colors duration-500"
           >
-            <X className="w-[1.6rem] h-[1.6rem]" />
+            <X className="w-4 h-4" />
           </button>
         )}
       </div>
       {open && results.length > 0 && (
-        <ul className="absolute top-full mt-2 right-0 bg-shadow rounded-[0.4rem] list-none p-0 m-0 w-136 z-50 shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)] overflow-hidden">
+        <ul className="absolute top-full mt-1 right-0 bg-shadow rounded-sm list-none p-0 m-0 w-full sm:w-136 z-50 shadow-[0_0.3125rem_0.9375rem_0_rgba(0,0,0,0.4)] overflow-hidden">
           {results.map((post) => (
             <li
               key={post.slug}
@@ -87,10 +87,10 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
               <Link
                 href={`/${post.slug}`}
                 onClick={close}
-                className="block px-[1.5rem] py-[1rem] hover:bg-background"
+                className="block px-4 py-2.5 hover:bg-background"
               >
                 <span className="block text-highlight-1">{post.title}</span>
-                <span className="block text-shadow-light text-[1.4rem] line-clamp-1">
+                <span className="block text-shadow-light text-sm line-clamp-1">
                   {post.excerpt}
                 </span>
               </Link>

--- a/components/SearchBox/SearchBox.tsx
+++ b/components/SearchBox/SearchBox.tsx
@@ -65,7 +65,7 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
           onKeyDown={(e) => {
             if (e.key === "Escape") close();
           }}
-          className="search-input bg-background text-text rounded-[0.4rem] pl-[1rem] pr-[3rem] py-[0.5rem] text-[1.4rem] outline-none border-0 w-full"
+          className="search-input bg-background text-text rounded-[0.4rem] pl-4 pr-12 py-4 text-[1.4rem] outline-none border-0 w-full"
         />
         {query && (
           <button
@@ -78,7 +78,7 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
         )}
       </div>
       {open && results.length > 0 && (
-        <ul className="absolute top-full mt-[0.5rem] right-0 bg-shadow rounded-[0.4rem] list-none p-0 m-0 w-[34rem] z-50 shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)] overflow-hidden">
+        <ul className="absolute top-full mt-2 right-0 bg-shadow rounded-[0.4rem] list-none p-0 m-0 w-136 z-50 shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)] overflow-hidden">
           {results.map((post) => (
             <li
               key={post.slug}

--- a/components/SearchBox/SearchBox.tsx
+++ b/components/SearchBox/SearchBox.tsx
@@ -63,7 +63,7 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
         onKeyDown={(e) => {
           if (e.key === "Escape") close();
         }}
-        className="search-input bg-background text-text rounded-[0.4rem] px-[1rem] py-[0.5rem] text-[1.4rem] outline-none border-0 w-full"
+        className="search-input bg-background text-text rounded-[0.4rem] p-[1rem] text-[1.4rem] outline-none border-0 w-full"
       />
       {open && results.length > 0 && (
         <ul className="absolute top-full mt-[0.5rem] right-0 bg-shadow rounded-[0.4rem] list-none p-0 m-0 w-[34rem] z-50 shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)] overflow-hidden">

--- a/components/SearchBox/SearchBox.tsx
+++ b/components/SearchBox/SearchBox.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useRef, useEffect, useMemo } from "react";
+import Link from "next/link";
+import Fuse from "fuse.js";
+
+type Post = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  tags?: string[];
+};
+
+export default function SearchBox({ posts }: { posts: Post[] }) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(posts, {
+        keys: ["title", "excerpt", "tags"],
+        threshold: 0.4,
+        minMatchCharLength: 2,
+      }),
+    [posts]
+  );
+
+  const results =
+    query.trim().length >= 2
+      ? fuse.search(query.trim()).slice(0, 6).map((r) => r.item)
+      : [];
+
+  useEffect(() => {
+    function onPointerDown(e: PointerEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, []);
+
+  function close() {
+    setOpen(false);
+    setQuery("");
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        type="search"
+        placeholder="Search..."
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") close();
+        }}
+        className="search-input bg-background text-text rounded-[0.4rem] px-[1rem] py-[0.5rem] text-[1.4rem] outline-none border-0 w-[18rem]"
+      />
+      {open && results.length > 0 && (
+        <ul className="absolute top-full mt-[0.5rem] right-0 bg-shadow rounded-[0.4rem] list-none p-0 m-0 w-[34rem] z-50 shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)] overflow-hidden">
+          {results.map((post) => (
+            <li
+              key={post.slug}
+              className="border-b border-background last:border-b-0"
+            >
+              <Link
+                href={`/${post.slug}`}
+                onClick={close}
+                className="block px-[1.5rem] py-[1rem] hover:bg-background"
+              >
+                <span className="block text-highlight-1">{post.title}</span>
+                <span className="block text-shadow-light text-[1.4rem] line-clamp-1">
+                  {post.excerpt}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/SearchBox/SearchBox.tsx
+++ b/components/SearchBox/SearchBox.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useMemo } from "react";
 import Link from "next/link";
 import Fuse from "fuse.js";
+import { X } from "react-feather";
 
 type Post = {
   slug: string;
@@ -51,20 +52,31 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
 
   return (
     <div ref={containerRef} className="relative">
-      <input
-        type="search"
-        placeholder="Search..."
-        value={query}
-        onChange={(e) => {
-          setQuery(e.target.value);
-          setOpen(true);
-        }}
-        onFocus={() => setOpen(true)}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") close();
-        }}
-        className="search-input bg-background text-text rounded-[0.4rem] p-[1rem] text-[1.4rem] outline-none border-0 w-full"
-      />
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="Search..."
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") close();
+          }}
+          className="search-input bg-background text-text rounded-[0.4rem] pl-[1rem] pr-[3rem] py-[0.5rem] text-[1.4rem] outline-none border-0 w-full"
+        />
+        {query && (
+          <button
+            onClick={close}
+            aria-label="Clear search"
+            className="absolute right-[0.6rem] top-1/2 -translate-y-1/2 text-shadow-light hover:text-highlight-2 transition-colors duration-500"
+          >
+            <X className="w-[1.6rem] h-[1.6rem]" />
+          </button>
+        )}
+      </div>
       {open && results.length > 0 && (
         <ul className="absolute top-full mt-[0.5rem] right-0 bg-shadow rounded-[0.4rem] list-none p-0 m-0 w-[34rem] z-50 shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)] overflow-hidden">
           {results.map((post) => (

--- a/components/SearchBox/SearchBox.tsx
+++ b/components/SearchBox/SearchBox.tsx
@@ -63,7 +63,7 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
         onKeyDown={(e) => {
           if (e.key === "Escape") close();
         }}
-        className="search-input bg-background text-text rounded-[0.4rem] px-[1rem] py-[0.5rem] text-[1.4rem] outline-none border-0 w-[18rem]"
+        className="search-input bg-background text-text rounded-[0.4rem] px-[1rem] py-[0.5rem] text-[1.4rem] outline-none border-0 w-full"
       />
       {open && results.length > 0 && (
         <ul className="absolute top-full mt-[0.5rem] right-0 bg-shadow rounded-[0.4rem] list-none p-0 m-0 w-[34rem] z-50 shadow-[0_0.5rem_1.5rem_0_rgba(0,0,0,0.4)] overflow-hidden">

--- a/components/SocialLinks/SocialLinks.tsx
+++ b/components/SocialLinks/SocialLinks.tsx
@@ -2,22 +2,22 @@ import { Twitter, GitHub, Rss } from 'react-feather';
 
 export default function SocialLinks() {
   return (
-    <div className="flex mt-6 sm:mt-0">
+    <div className="flex mt-4 sm:mt-0">
       <a
         href="https://twitter.com/danielwrobert"
         rel="external"
-        className="text-shadow-light hover:text-highlight-3 mr-8 inline-flex"
+        className="text-shadow-light hover:text-highlight-3 mr-5 inline-flex"
         aria-label="Twitter"
       >
-        <Twitter className="w-[3.2rem] h-[3.2rem]" />
+        <Twitter className="w-8 h-8" />
       </a>
       <a
         href="https://github.com/danielwrobert"
         rel="external"
-        className="text-shadow-light hover:text-highlight-3 mr-8 inline-flex"
+        className="text-shadow-light hover:text-highlight-3 mr-5 inline-flex"
         aria-label="GitHub"
       >
-        <GitHub className="w-[3.2rem] h-[3.2rem]" />
+        <GitHub className="w-8 h-8" />
       </a>
       <a
         href="/rss.xml"
@@ -25,7 +25,7 @@ export default function SocialLinks() {
         className="text-shadow-light hover:text-highlight-3 inline-flex"
         aria-label="RSS Feed"
       >
-        <Rss className="w-[3.2rem] h-[3.2rem]" />
+        <Rss className="w-8 h-8" />
       </a>
     </div>
   );

--- a/components/Stitch/Stitch.tsx
+++ b/components/Stitch/Stitch.tsx
@@ -8,8 +8,8 @@ interface StitchProps {
 export default function Stitch({
   color = 'var(--color-shadow-light)',
   strokeWidth = '4',
-  width = '4.5rem',
-  margin = '0 auto 4.5rem',
+  width = '2.8125rem',
+  margin = '0 auto 2.8125rem',
 }: StitchProps) {
   return (
     <svg

--- a/components/TOC/TOC.tsx
+++ b/components/TOC/TOC.tsx
@@ -1,6 +1,6 @@
 export default function TOC({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-shadow rounded-[0.5rem] p-6 my-[1.8rem]">
+    <div className="bg-shadow rounded-sm p-4 my-[1.125rem]">
       <h2 className="!text-highlight-4">Series Table of Contents:</h2>
       {children}
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4994,7 +4994,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4994,6 +4994,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "bright": "^1.0.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "fuse.js": "^7.3.0",
         "gray-matter": "^4.0.3",
         "js-cookie": "^3.0.5",
         "next": "16.2.3",
@@ -4993,6 +4994,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5042,6 +5044,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bright": "^1.0.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "fuse.js": "^7.3.0",
     "gray-matter": "^4.0.3",
     "js-cookie": "^3.0.5",
     "next": "16.2.3",

--- a/tests/components/Nav.test.tsx
+++ b/tests/components/Nav.test.tsx
@@ -9,8 +9,12 @@ vi.mock("next/navigation", () => ({
 describe("Nav", () => {
   it('renders the DWR logo link pointing to "/"', () => {
     render(<Nav />);
-    const logo = screen.getByText("DWR");
-    expect(logo.closest("a")).toHaveAttribute("href", "/");
+    // "DWR" appears in both the desktop nav and the mobile bar
+    const logos = screen.getAllByText("DWR");
+    expect(logos.length).toBeGreaterThanOrEqual(1);
+    logos.forEach((logo) =>
+      expect(logo.closest("a")).toHaveAttribute("href", "/")
+    );
   });
 
   it('renders a Notebook link pointing to "/notebook"', () => {


### PR DESCRIPTION
## Summary

- Adds fuzzy full-text search across all 27 posts with zero backend infrastructure
- Search index is built server-side at request time and passed to the client as serialised JSON — no extra network round-trip when the user types
- Results appear as an inline dropdown in the nav bar, matching the live site UX

## Architecture

```
Header (async server component)
  └─ fetches getBlogPostList() on the server
  └─ passes {slug, title, excerpt, tags}[] to SearchBox
       SearchBox ("use client")
         └─ builds Fuse.js index in useMemo
         └─ renders results dropdown on every keystroke
  └─ passes SearchBox as searchSlot prop to Nav
       Nav ("use client")
         └─ renders searchSlot as final <li> in the nav flex row
```

## Behaviour

- Appears inline at the right end of the nav bar (after About)
- Fuzzy search over `title`, `excerpt`, and `tags` fields (threshold 0.4)
- Minimum 2 characters to trigger, up to 6 results shown
- Each result shows post title (purple) + excerpt snippet (one line, truncated)
- Click a result → navigate to post and close search
- Press Escape or click outside → close and clear input
- Placeholder text styled with the site's `shadow-light` colour

## Test plan

- [ ] `npm run dev` → search input visible in nav bar on all pages
- [ ] Type "javascript" → relevant posts appear in dropdown
- [ ] Type a partial word (e.g. "stor") → fuzzy matches appear
- [ ] Click a result → navigates to the correct post, input clears
- [ ] Press Escape → dropdown closes, input clears
- [ ] Click outside the search box → dropdown closes
- [ ] `npm run build` → clean static build, no server/client boundary errors
- [ ] `npm run test` → all 6 Vitest tests pass (Nav tests use `<Nav />` without searchSlot — prop is optional)

https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11)_