### PR TITLE
Fix mobile nav: prevent iOS zoom and close overlay on search result click

### DIFF
--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -35,12 +35,6 @@ export default function Nav({ posts = [] }: { posts?: Post[] }) {
     return () => document.removeEventListener("keydown", onKey);
   }, [mobileOpen]);
 
-  // Close overlay on any client-side navigation
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMobileOpen(false);
-  }, [pathname]);
-
   return (
     <>
       {/* ── Desktop nav (hidden on mobile) ─────────────────────── */}
@@ -118,7 +112,7 @@ export default function Nav({ posts = [] }: { posts?: Post[] }) {
             </ul>
           </nav>
 
-          <SearchBox posts={posts} />
+          <SearchBox posts={posts} onNavigate={() => setMobileOpen(false)} />
         </div>
       )}
     </>

--- a/components/SearchBox/SearchBox.tsx
+++ b/components/SearchBox/SearchBox.tsx
@@ -12,7 +12,13 @@ type Post = {
   tags?: string[];
 };
 
-export default function SearchBox({ posts }: { posts: Post[] }) {
+export default function SearchBox({
+  posts,
+  onNavigate,
+}: {
+  posts: Post[];
+  onNavigate?: () => void;
+}) {
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -65,7 +71,7 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
           onKeyDown={(e) => {
             if (e.key === "Escape") close();
           }}
-          className="search-input bg-background text-text rounded-sm pl-2.5 pr-7.5 py-2.5 text-base outline-none border-0 w-full"
+          className="search-input bg-background text-text rounded-sm pl-2.5 pr-7.5 py-2.5 text-[1.6rem] sm:text-base outline-none border-0 w-full"
         />
         {query && (
           <button
@@ -86,7 +92,7 @@ export default function SearchBox({ posts }: { posts: Post[] }) {
             >
               <Link
                 href={`/${post.slug}`}
-                onClick={close}
+                onClick={() => { close(); onNavigate?.(); }}
                 className="block px-4 py-2.5 hover:bg-background"
               >
                 <span className="block text-highlight-1">{post.title}</span>


### PR DESCRIPTION
## Summary

- **iOS zoom**: Search input was `text-base` = `1rem` = 10px at our 62.5% rem scale. iOS Safari automatically zooms when a focused input is below 16px. Fixed by using `text-[1.6rem]` (16px) on mobile and keeping `text-base` on desktop via `sm:text-base`.
- **Overlay not closing**: Clicking a search result called `close()` inside `SearchBox` (clearing the dropdown) but had no way to signal the parent `Nav` to close the overlay. Added an `onNavigate?: () => void` prop to `SearchBox`; the mobile overlay passes `() => setMobileOpen(false)`. Also removed the `useEffect([pathname])` workaround, which was unreliable when navigating to the already-active page and required an ESLint disable comment.

## Test plan

- [ ] On a mobile device/emulator, tap the search input — page should not zoom
- [ ] Type a query, tap a result — overlay closes and navigates to the post
- [ ] Tapping a result while already on that page still closes the overlay
- [ ] Desktop search behavior unchanged
- [ ] `npm run lint && npx tsc --noEmit && npx vitest run` all pass

https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjnY7gtf3U5os4cjgJQ11)_